### PR TITLE
Merged, BugFixes and improved the ClearIf function

### DIFF
--- a/src/main/java/com/example/demopugspring/engine/MapperEngine.java
+++ b/src/main/java/com/example/demopugspring/engine/MapperEngine.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.example.demopugspring.engine.operation.AbstractOperation;
 import com.example.demopugspring.factory.ContextSingleton;
 import com.example.demopugspring.filter.MatchesValueFilter;
 import com.example.demopugspring.model.Integration;
@@ -332,7 +331,7 @@ public class MapperEngine {
 						fieldAfterOperation(msg, tmp, mapper.getKey(), mapper.getValue(), mapper.getCategory(), errorList);
 						break;
 					case AFTER_SWAP:
-						swapAfterOperarion(msg, tmp, mapper.getKey(), mapper.getValue(), mapperCategory, errorList);
+						swapAfterOperation(msg, tmp, mapper.getKey(), mapper.getValue(), mapper.getCategory(), errorList);
 						break;
 					case CLEAR_IF:
 						clearIfOperation(tmp, mapper.getKey(), mapper.getValue(), errorList);
@@ -340,7 +339,6 @@ public class MapperEngine {
 					case TRANSCODING:
                         transcode(tmp, mapper.getKey(), mapper.getValue(), errorList);
 						break;
-
 					case REPLACE:
 						replaceOperation(tmp, mapper.getKey(), mapper.getValue(), errorList);
 						break;

--- a/src/main/java/com/example/demopugspring/engine/MapperEngine.java
+++ b/src/main/java/com/example/demopugspring/engine/MapperEngine.java
@@ -223,9 +223,9 @@ public class MapperEngine {
 	}
 	
 	public void clearIfOperation(Terser tmp, List<String> fields, String value, List<MapperError> errorList) {
-		ClearFilteredOperation clearOperation = new ClearFilteredOperation(value, fields, new MatchesValueFilter(value));
-		try {
-			clearOperation.doOperation(tmp.getSegment(fields.get(0).split("-")[0]).getMessage());
+        try {
+            ClearFilteredOperation clearOperation = new ClearFilteredOperation(value, fields, new MatchesValueFilter(value, tmp));
+            clearOperation.doOperation(tmp.getSegment(fields.get(0).split("-")[0]).getMessage());
         }catch(HL7Exception e) {
 		    errorList.add(new MapperError(e.getError().name(), e.getDetail().toString()));	
         }

--- a/src/main/java/com/example/demopugspring/filter/MatchesValueFilter.java
+++ b/src/main/java/com/example/demopugspring/filter/MatchesValueFilter.java
@@ -1,19 +1,43 @@
 package com.example.demopugspring.filter;
 
+import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.Primitive;
+import ca.uhn.hl7v2.util.Terser;
 
 public class MatchesValueFilter implements Filter {
 
-	String valueToCheck;
+    private static final String PARSE_TOKEN = "=";
+    private String valueToCheck;
 
-	public MatchesValueFilter(String valueToCheck) {
-		this.valueToCheck = valueToCheck;
+    public MatchesValueFilter(String valueToCheck, Terser tmp) throws HL7Exception {
+
+        this.valueToCheck = parseValue(valueToCheck, tmp);
+
 	}
+
+    private String parseValue(String value, Terser tmp) throws HL7Exception {
+        String fieldValue;
+        String pathToBeReplace;
+
+        int firstIndex = value.indexOf(PARSE_TOKEN);
+        int lastIndex = value.lastIndexOf(PARSE_TOKEN);
+
+        if (firstIndex < lastIndex) {
+            pathToBeReplace = value.substring(firstIndex + 1, lastIndex);
+            fieldValue = tmp.get(pathToBeReplace);
+            if (fieldValue == null) {
+                fieldValue = "";
+            }
+            value = value.replaceAll(PARSE_TOKEN + pathToBeReplace + PARSE_TOKEN, fieldValue);
+        }
+        return value;
+    }
+
 	@Override
 	public boolean doFilter(Primitive primitive) {
 		boolean primitiveHasCondition = false;
-		if (primitive.getValue() == null && valueToCheck.isBlank()) {
-			primitiveHasCondition = true;
+		if (primitive.getValue() == null) {
+            primitiveHasCondition = valueToCheck.isBlank();
 		} else {
 			primitiveHasCondition = primitive.getValue().matches(valueToCheck);
 		}

--- a/src/main/java/com/example/demopugspring/filter/MatchesValueFilter.java
+++ b/src/main/java/com/example/demopugspring/filter/MatchesValueFilter.java
@@ -7,12 +7,15 @@ import ca.uhn.hl7v2.util.Terser;
 public class MatchesValueFilter implements Filter {
 
     private static final String PARSE_TOKEN = "=";
+    private static final String NOT_OPERATOR = "!";
     private String valueToCheck;
+    private boolean negativize;
 
-    public MatchesValueFilter(String valueToCheck, Terser tmp) throws HL7Exception {
+    public MatchesValueFilter(String value, Terser tmp) throws HL7Exception {
 
-        this.valueToCheck = parseValue(valueToCheck, tmp);
-
+        this.valueToCheck = parseValue(value, tmp);
+        negativize = value.contains(NOT_OPERATOR);
+        this.valueToCheck = valueToCheck.replace(NOT_OPERATOR, "");
 	}
 
     private String parseValue(String value, Terser tmp) throws HL7Exception {
@@ -41,7 +44,7 @@ public class MatchesValueFilter implements Filter {
 		} else {
 			primitiveHasCondition = primitive.getValue().matches(valueToCheck);
 		}
-		return primitiveHasCondition;
+        return primitiveHasCondition ^ negativize;
 	}
 
 }

--- a/src/main/java/com/example/demopugspring/visitor/HAPIPath.java
+++ b/src/main/java/com/example/demopugspring/visitor/HAPIPath.java
@@ -2,10 +2,18 @@ package com.example.demopugspring.visitor;
 
 
 public class HAPIPath {
-	public static String WRONG_PATH = "Wrong path specified.";
+
+	protected static final String WRONG_PATH = "Wrong path specified.";
+	private static final String DEAFULT_INDEX = "1";
+	private static final Integer DEFAULT_REP = 0;
 
 	private String structureName;
 	private Integer repetition;
+
+	public HAPIPath() {
+		structureName = DEAFULT_INDEX;
+		repetition = DEFAULT_REP;
+	}
 
 	public HAPIPath(String name, Integer repetition) {
 		structureName = name;

--- a/src/main/java/com/example/demopugspring/visitor/MapperVisitor.java
+++ b/src/main/java/com/example/demopugspring/visitor/MapperVisitor.java
@@ -254,12 +254,30 @@ public class MapperVisitor implements MessageVisitor{
 	private void getIndexs(String spec) throws HL7Exception {
         StringTokenizer tok = new StringTokenizer(spec, "-", false);
 		parseSegmentPathSpec(tok.nextToken());
-		field = parseNameAndRepetition(tok.nextToken());
-		component = parseNameAndRepetition(tok.nextToken());
-		if (tok.hasMoreTokens()) {
-			subComponent = parseNameAndRepetition(tok.nextToken());
-		}
+		field = parsePath(tok);
+		component = parsePath(tok);
+		subComponent = parsePath(tok);
     }
+
+	/**
+	 * Parses the path of the given tokenizer, if the tokenizer has a valid
+	 * value it will create the respective HAPIPath otherwise it will create a
+	 * default one
+	 * 
+	 * @param tok
+	 * @return
+	 * @throws HL7Exception
+	 */
+	private HAPIPath parsePath(StringTokenizer tok) throws HL7Exception {
+		HAPIPath result;
+		if (tok.hasMoreTokens()) {
+			result = parseNameAndRepetition(tok.nextToken());
+		} else {
+			result = new HAPIPath();
+		}
+
+		return result;
+	}
 
 	/**
 	 * This method parses if the path given has groups and group reps indicators

--- a/src/main/java/com/example/demopugspring/visitor/StandardVisitor.java
+++ b/src/main/java/com/example/demopugspring/visitor/StandardVisitor.java
@@ -203,11 +203,29 @@ public class StandardVisitor implements MessageVisitor {
 	private void getIndexs(String spec) throws HL7Exception {
 		StringTokenizer tok = new StringTokenizer(spec, "-", false);
 		parseSegmentPathSpec(tok.nextToken());
-		field = parseNameAndRepetition(tok.nextToken());
-		component = parseNameAndRepetition(tok.nextToken());
+		field = parsePath(tok);
+		component = parsePath(tok);
+		subComponent = parsePath(tok);
+	}
+
+	/**
+	 * Parses the path of the given tokenizer, if the tokenizer has a valid
+	 * value it will create the respective HAPIPath otherwise it will create a
+	 * default one
+	 * 
+	 * @param tok
+	 * @return
+	 * @throws HL7Exception
+	 */
+	private HAPIPath parsePath(StringTokenizer tok) throws HL7Exception {
+		HAPIPath result;
 		if (tok.hasMoreTokens()) {
-			subComponent = parseNameAndRepetition(tok.nextToken());
+			result = parseNameAndRepetition(tok.nextToken());
+		} else {
+			result = new HAPIPath();
 		}
+
+		return result;
 	}
 
 	/**

--- a/src/test/java/com/example/demopugspring/engine/MapperEngineTest.java
+++ b/src/test/java/com/example/demopugspring/engine/MapperEngineTest.java
@@ -218,6 +218,25 @@ class MapperEngineTest {
 
 	}
 
+	@Test
+	void testReplaceOpearion() throws HL7Exception {
+		String messageString = "MSH|^~\\&|GH|CCA|ehCOS|CCA|20201112103816||ADT^A31|1601940378|P|2.4|||AL\r\n"
+				+ "PID|||59594292^^^JMS^NS~1234^^^CCA^NS~1234553^^^HCD^NS~883885^^^CUFP^NS~123456789^^^NIF^PT~22810278800^^^N_BENEF^~32169833^^^N_BI^||TESTE^JULIA BABO CORREIA||19910302000000|F|||RUA DO 4 DE TESTE, N\\XBA\\ 88, 3\\XBA\\ DTO^^LISBOA^11^1350-275^1||^^PH^^^^^^^^^999999999~^^X.400^juliap@gmail.com|||U|||999999999||||PORTUGAL|||||1^PORTUGAL||N\r\n";
+
+		Message outMessage = ContextSingleton.getInstance().getPipeParser().parse(messageString);
+		outMessage.parse(messageString);
+		Terser t = new Terser(outMessage);
+		Terser terserSpy = Mockito.spy(t);
+
+		List<MapperError> errors = Mockito.mock(List.class);
+		MapperEngine meng = new MapperEngine();
+
+		String[] testeListaKeys = { "/PID-7" };
+		meng.replaceOperation(terserSpy, Arrays.asList(testeListaKeys), "(00)+", errors);
+
+		assertEquals("19910302", terserSpy.get("/PID-7"));
+	}
+
 
 		@Test
 		void testJoinFieldsPatient() throws HL7Exception {


### PR DESCRIPTION
Now in the regex you can specify a path so the value on that primitive will be considered, for example (JMS|=/MSH-4=) cleans the composites that have on a subcomponent JSM or the value on /MSH-4 path.