### PR TITLE
Removed behavior of iterating keys @ Operations 

### DIFF
--- a/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
@@ -1,23 +1,22 @@
 package com.example.demopugspring.engine.operation;
 
-import ca.uhn.hl7v2.model.Message;
-import ca.uhn.hl7v2.util.Terser;
-import com.example.demopugspring.engine.MapperEngine;
-import com.example.demopugspring.engine.MapperError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.example.demopugspring.engine.MapperEngine;
+import com.example.demopugspring.engine.MapperError;
+
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.util.Terser;
+
 /**
  * This abstract class serves as the base for any Operation to be applied to an
- * HL7 message. By default, {@link #map()} calls {@link #mapKey(String)} for
- * each in {@link #keys}. So, in order to implement this class, one would only
- * need to implement method {@link #mapKey(String)}. If, for some reason, a
- * different behavior is needed and keys are not meant to be iterated, one can
- * override {@link #map()} directly and change the message there.
+ * HL7 message. In order to implement this class, one would only need to
+ * implement method {@link #map()}.
  * </p>
  * An example of implementing this class can be seen at {@link Text}.
  * </p>

--- a/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
@@ -82,13 +82,7 @@ public abstract class AbstractOperation {
 		return errors;
 	}
 
-	public void map() {
-		for (String key : keys) {
-			mapKey(key);
-		}
-	}
-
-	protected abstract void mapKey(String key);
+	public abstract void map();
 
 	@Override
 	public int hashCode() {

--- a/src/main/java/com/example/demopugspring/engine/operation/Field.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/Field.java
@@ -14,9 +14,9 @@ import ca.uhn.hl7v2.util.Terser;
 
 /**
  * This operation inserts/replaces the value of the message at the path given by
- * each key in {@link AbstractOperation#keys}, with the value at the path given
- * by {@link AbstractOperation#value}, replacing any previous content in the
- * message.
+ * the first key in {@link AbstractOperation#keys}, with the value at the path
+ * given by {@link AbstractOperation#value}, replacing any previous content in
+ * the message.
  * </p>
  * If the key contains the '#' character, instead of using
  * {@link ca.uhn.hl7v2.util.Terser}, it will use

--- a/src/main/java/com/example/demopugspring/engine/operation/Field.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/Field.java
@@ -18,7 +18,7 @@ import ca.uhn.hl7v2.util.Terser;
  * by {@link AbstractOperation#value}, replacing any previous content in the
  * message.
  * </p>
- * If a key contains the '#' character, instead of using
+ * If the key contains the '#' character, instead of using
  * {@link ca.uhn.hl7v2.util.Terser}, it will use
  * {@link com.example.demopugspring.visitor.StandardVisitor} to get the types to
  * be changed.
@@ -41,13 +41,8 @@ public class Field extends AbstractOperation {
 			errors.add(new MapperError(keys.toString(), e.getMessage()));
 		}
 
-		for (String key : keys) {
-			mapKey(key);
-		}
-	}
+		String key = keys.get(0);
 
-	@Override
-	protected void mapKey(String key) {
 		try {
 			if (key.contains("#")) {
 				StandardVisitor visitor = new StandardVisitor(key);
@@ -86,5 +81,4 @@ public class Field extends AbstractOperation {
 		Field other = (Field) obj;
 		return Objects.equals(fieldValue, other.fieldValue);
 	}
-
 }

--- a/src/main/java/com/example/demopugspring/engine/operation/Text.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/Text.java
@@ -15,7 +15,7 @@ import java.util.List;
  * path specified in each key included in {@link AbstractOperation#keys},
  * replacing any previous content in the message.
  * </p>
- * If a key contains the '#' character, instead of using
+ * If the key contains the '#' character, instead of using
  * {@link ca.uhn.hl7v2.util.Terser}, it will use
  * {@link com.example.demopugspring.visitor.StandardVisitor} to get the types to
  * be changed.
@@ -28,7 +28,9 @@ public class Text extends AbstractOperation {
 	}
 
 	@Override
-	protected void mapKey(String key) {
+	public void map() {
+		String key = keys.get(0);
+
 		try {
 			if (key.contains("#")) {
 				StandardVisitor visitor = new StandardVisitor(key);

--- a/src/main/java/com/example/demopugspring/engine/operation/Text.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/Text.java
@@ -1,18 +1,19 @@
 package com.example.demopugspring.engine.operation;
 
-import ca.uhn.hl7v2.HL7Exception;
-import ca.uhn.hl7v2.model.Message;
-import ca.uhn.hl7v2.model.Type;
-import ca.uhn.hl7v2.util.Terser;
+import java.util.List;
+
 import com.example.demopugspring.engine.MapperEngine;
 import com.example.demopugspring.engine.MapperError;
 import com.example.demopugspring.visitor.StandardVisitor;
 
-import java.util.List;
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.model.Type;
+import ca.uhn.hl7v2.util.Terser;
 
 /**
  * This Operation inserts the text in {@link AbstractOperation#value} at the
- * path specified in each key included in {@link AbstractOperation#keys},
+ * path specified in the first key included in {@link AbstractOperation#keys},
  * replacing any previous content in the message.
  * </p>
  * If the key contains the '#' character, instead of using

--- a/src/main/java/com/example/demopugspring/model/Mapper.java
+++ b/src/main/java/com/example/demopugspring/model/Mapper.java
@@ -22,6 +22,7 @@ public class Mapper {
 	private List<String> key;
 	private String value;
 	private Mapper.Category category;
+
 	public Mapper(List<String> key, String value, Mapper.Category category) {
 		this.key = key;
 		this.value = value;
@@ -29,20 +30,20 @@ public class Mapper {
 	}
 
 	public enum Category {
-		TEXT("Text"),
-		FIELD("field"),
-		SWAP("swap"),
-		TRANSCODING("transcoding"),
-		SEGMENT("segment"),
-		JOIN("join"),
-		NUMERIC("numeric"),
-		CONTACT("contact"),
-		AFTER_SWAP("after_swap"),
-		AFTER_FIELD("after_field"),
-		AFTER_JOIN_FIELDS("after_join_fields"),
-		CLEAR_IF("clear_if"),
-		ADD_SNS("add_sns"),
-		REPLACE("replace");
+			TEXT("Text"),
+			FIELD("Field"),
+			SWAP("swap"),
+			TRANSCODING("transcoding"),
+			SEGMENT("segment"),
+			JOIN("join"),
+			NUMERIC("numeric"),
+			CONTACT("contact"),
+			AFTER_SWAP("after_swap"),
+			AFTER_FIELD("after_field"),
+			AFTER_JOIN_FIELDS("after_join_fields"),
+			CLEAR_IF("clear_if"),
+			ADD_SNS("add_sns"),
+			REPLACE("replace");
 
 		private final String value;
 

--- a/src/test/java/com/example/demopugspring/engine/operation/FieldTest.java
+++ b/src/test/java/com/example/demopugspring/engine/operation/FieldTest.java
@@ -35,9 +35,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PATIENT_VISIT/PV1-2";
-		String key2 = "/PATIENT/PATIENT_VISIT/PV1-3";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-2");
 
 		// Change /PATIENT/PATIENT_VISIT/PV1-14 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-14"), "NEW_VALUE");
@@ -47,14 +45,12 @@ class FieldTest {
 
 		AbstractOperation fieldOperation = new Field(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("Consultas", outgoingTerser.get(key1));
-		assertEquals("3", outgoingTerser.get(key2));
+		assertEquals("Consultas", outgoingTerser.get("/PATIENT/PATIENT_VISIT/PV1-2"));
 
 		fieldOperation.map();
 
 		assertTrue(fieldOperation.errors.isEmpty());
-		assertEquals("CONSULTAS", outgoingTerser.get(key1));
-		assertEquals("CONSULTAS", outgoingTerser.get(key2));
+		assertEquals("CONSULTAS", outgoingTerser.get("/PATIENT/PATIENT_VISIT/PV1-2"));
 	}
 
 	@Test
@@ -74,9 +70,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PATIENT_VISIT/PV1-2";
-		String key2 = "/PATIENT/PATIENT_VISIT/PV1-3";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-2");
 
 		// Change /PATIENT/PATIENT_VISIT/PV1-14 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-14"), "NEW_VALUE");
@@ -86,14 +80,12 @@ class FieldTest {
 
 		AbstractOperation fieldOperation = new Field(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("Consultas", outgoingTerser.get(key1));
-		assertEquals("3", outgoingTerser.get(key2));
+		assertEquals("Consultas", outgoingTerser.get("/PATIENT/PATIENT_VISIT/PV1-2"));
 
 		fieldOperation.map();
 
 		assertTrue(fieldOperation.errors.isEmpty());
-		assertEquals("NEW_VALUE", outgoingTerser.get(key1));
-		assertEquals("NEW_VALUE", outgoingTerser.get(key2));
+		assertEquals("NEW_VALUE", outgoingTerser.get("/PATIENT/PATIENT_VISIT/PV1-2"));
 	}
 
 	@Test
@@ -113,8 +105,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)");
 
 		// Change /PATIENT/PATIENT_VISIT/PV1-3 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-3"), "404");
@@ -154,8 +145,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)");
 
 		// Change /PATIENT/PATIENT_VISIT/PV1-3 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PATIENT_VISIT/PV1-3"), "404");
@@ -195,9 +185,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-1");
 
 		// Change /PATIENT/PID-3-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PID-3-1"), "NEW_VALUE");
@@ -207,14 +195,12 @@ class FieldTest {
 
 		AbstractOperation operation = new Field(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("244288437", outgoingTerser.get(key1));
-		assertEquals("ECO PELVICA", outgoingTerser.get(key2));
+		assertEquals("244288437", outgoingTerser.get("/PATIENT/PID-4-1"));
 
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("JMS43417401", outgoingTerser.get(key1));
-		assertEquals("JMS43417401", outgoingTerser.get(key2));
+		assertEquals("JMS43417401", outgoingTerser.get("/PATIENT/PID-4-1"));
 	}
 
 	@Test
@@ -234,9 +220,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-1");
 
 		// Change /PATIENT/PID-3-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PID-3-1"), "NEW_VALUE");
@@ -246,14 +230,12 @@ class FieldTest {
 
 		AbstractOperation operation = new Field(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("244288437", outgoingTerser.get(key1));
-		assertEquals("ECO PELVICA", outgoingTerser.get(key2));
+		assertEquals("244288437", outgoingTerser.get("/PATIENT/PID-4-1"));
 
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("NEW_VALUE", outgoingTerser.get(key1));
-		assertEquals("NEW_VALUE", outgoingTerser.get(key2));
+		assertEquals("NEW_VALUE", outgoingTerser.get("/PATIENT/PID-4-1"));
 	}
 
 	@Test
@@ -273,8 +255,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4");
 
 		// Change /PATIENT/PID-3-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PID-3-1"), "NEW_VALUE");
@@ -314,8 +295,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4");
 
 		// Change /PATIENT/PID-3-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/PATIENT/PID-3-1"), "NEW_VALUE");
@@ -355,9 +335,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-#";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-#";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-#");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-46-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-46-1"), "1234");
@@ -370,14 +348,10 @@ class FieldTest {
 		Type pid4Field = outgoingTerser.getSegment("/PATIENT/PID").getField(4, 0);
 		assertEquals("244288437^^^NIF^PT", pid4Field.encode());
 
-		Type obr32Field = outgoingTerser.getSegment("/ORDER/ORDER_DETAIL/OBR").getField(4, 0);
-		assertEquals("62009903^ECO PELVICA", obr32Field.encode());
-
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
 		assertEquals("20201108^20201108^20201108^20201108^20201108^20201108^20201108^20201108", pid4Field.encode());
-		assertEquals("20201108^20201108^20201108^20201108^20201108^20201108", obr32Field.encode());
 	}
 
 	@Test
@@ -397,9 +371,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-#";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-#";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-#");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-46-1 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-46-1"), "1234");
@@ -412,14 +384,10 @@ class FieldTest {
 		Type pid4Field = outgoingTerser.getSegment("/PATIENT/PID").getField(4, 0);
 		assertEquals("244288437^^^NIF^PT", pid4Field.encode());
 
-		Type obr32Field = outgoingTerser.getSegment("/ORDER/ORDER_DETAIL/OBR").getField(4, 0);
-		assertEquals("62009903^ECO PELVICA", obr32Field.encode());
-
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
 		assertEquals("1234^1234^1234^1234^1234^1234^1234^1234", pid4Field.encode());
-		assertEquals("1234^1234^1234^1234^1234^1234", obr32Field.encode());
 	}
 
 	@Test
@@ -439,9 +407,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-32-1-3";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-1");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");
@@ -458,7 +424,7 @@ class FieldTest {
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("REBELO&NEW_VALUE&REBELO", obr32Field.encode());
+		assertEquals("REBELO&NEW_VALUE&JOSE", obr32Field.encode());
 	}
 
 	@Test
@@ -478,9 +444,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-32-1-3";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-1");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");
@@ -497,7 +461,7 @@ class FieldTest {
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("NEW_VALUE&NEW_VALUE&NEW_VALUE", obr32Field.encode());
+		assertEquals("NEW_VALUE&NEW_VALUE&JOSE", obr32Field.encode());
 	}
 
 	@Test
@@ -517,8 +481,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4-2");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");
@@ -559,8 +522,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4-2");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");
@@ -601,8 +563,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-#";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-#");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");
@@ -639,8 +600,7 @@ class FieldTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-#";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-#");
 
 		// Change /ORDER/ORDER_DETAIL/OBR-32-1-2 value first
 		AbstractOperation textOperation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-2"), "NEW_VALUE");

--- a/src/test/java/com/example/demopugspring/engine/operation/TextTest.java
+++ b/src/test/java/com/example/demopugspring/engine/operation/TextTest.java
@@ -35,22 +35,17 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/MSH-4";
-		String key2 = "/MSH-6";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/MSH-4");
 
 		String value = "NEW_VALUE";
 
 		AbstractOperation operation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("CCTV", outgoingTerser.get(key1));
-		assertEquals("CCTV", outgoingTerser.get(key2));
-
+		assertEquals("CCTV", outgoingTerser.get("/MSH-4"));
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("NEW_VALUE", outgoingTerser.get(key1));
-		assertEquals("NEW_VALUE", outgoingTerser.get(key2));
+		assertEquals("NEW_VALUE", outgoingTerser.get("/MSH-4"));
 	}
 
 	@Test
@@ -70,8 +65,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)");
 
 		String value = "1234";
 
@@ -107,22 +101,18 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-1");
 
 		String value = "NEW_VALUE";
 
 		AbstractOperation operation = new Text(meng, incomingMessage, outgoingMessage, incomingTerser, outgoingTerser, keys, value);
 
-		assertEquals("244288437", outgoingTerser.get(key1));
-		assertEquals("ECO PELVICA", outgoingTerser.get(key2));
+		assertEquals("244288437", outgoingTerser.get("/PATIENT/PID-4-1"));
 
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("NEW_VALUE", outgoingTerser.get(key1));
-		assertEquals("NEW_VALUE", outgoingTerser.get(key2));
+		assertEquals("NEW_VALUE", outgoingTerser.get("/PATIENT/PID-4-1"));
 	}
 
 	@Test
@@ -142,8 +132,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4");
 
 		String value = "NEW_VALUE";
 
@@ -179,9 +168,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4-#";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-4-#";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4-#");
 
 		String value = "1234";
 
@@ -190,14 +177,10 @@ class TextTest {
 		Type pid4Field = outgoingTerser.getSegment("/PATIENT/PID").getField(4, 0);
 		assertEquals("244288437^^^NIF^PT", pid4Field.encode());
 
-		Type obr32Field = outgoingTerser.getSegment("/ORDER/ORDER_DETAIL/OBR").getField(4, 0);
-		assertEquals("62009903^ECO PELVICA", obr32Field.encode());
-
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
 		assertEquals("1234^1234^1234^1234^1234^1234^1234^1234", pid4Field.encode());
-		assertEquals("1234^1234^1234^1234^1234^1234", obr32Field.encode());
 	}
 
 	@Test
@@ -217,9 +200,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-1";
-		String key2 = "/ORDER/ORDER_DETAIL/OBR-32-1-3";
-		List<String> keys = Arrays.asList(new String[] { key1, key2 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-1");
 
 		String value = "NEW_VALUE";
 
@@ -232,7 +213,7 @@ class TextTest {
 		operation.map();
 
 		assertTrue(operation.errors.isEmpty());
-		assertEquals("NEW_VALUE&REBELO&NEW_VALUE", obr32Field.encode());
+		assertEquals("NEW_VALUE&REBELO&JOSE", obr32Field.encode());
 	}
 
 	@Test
@@ -252,8 +233,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/PATIENT/PID-4(#)-4-2";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/PATIENT/PID-4(#)-4-2");
 
 		String value = "1234";
 
@@ -290,8 +270,7 @@ class TextTest {
 		Terser incomingTerser = new Terser(incomingMessage);
 		Terser outgoingTerser = new Terser(outgoingMessage);
 
-		String key1 = "/ORDER/ORDER_DETAIL/OBR-32-1-#";
-		List<String> keys = Arrays.asList(new String[] { key1 });
+		List<String> keys = Arrays.asList("/ORDER/ORDER_DETAIL/OBR-32-1-#");
 
 		String value = "NEW_VALUE";
 


### PR DESCRIPTION
Iterating the keys of an operation and mapping each one isn't now the default behavior of AbstractOperation. If such behavior is needed, one must develop it at the implementing Operation level.