### PR TITLE
Code cleaning and uniformizing 

### DIFF
--- a/src/main/java/com/example/demopugspring/engine/MapperEngine.java
+++ b/src/main/java/com/example/demopugspring/engine/MapperEngine.java
@@ -24,7 +24,6 @@ import com.example.demopugspring.model.IntegrationMapper;
 import com.example.demopugspring.model.Mapper;
 import com.example.demopugspring.model.Mapper.Category;
 import com.example.demopugspring.operation.ClearFilteredOperation;
-import com.example.demopugspring.operation.FieldOperation;
 import com.example.demopugspring.operation.ReplaceOperation;
 import com.example.demopugspring.operation.SwapOperation;
 import com.example.demopugspring.properties.Codes;
@@ -38,7 +37,6 @@ import com.example.demopugspring.service.ApplicationService;
 import com.example.demopugspring.service.IntegrationMapperService;
 import com.example.demopugspring.service.IntegrationService;
 import com.example.demopugspring.service.MessageService;
-import com.example.demopugspring.visitor.MapperVisitor;
 import com.example.demopugspring.visitor.TranscodingVisitor;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -89,15 +87,8 @@ public class MapperEngine {
     @Autowired
     MessageService messageService;
 
-    private void textFields(String field, String text, Terser encodedMessage, Terser decodedMessage) throws HL7Exception {
-        MapperVisitor visitor;
 
-        visitor = new MapperVisitor(field, text);
-        visitor.start(decodedMessage.getSegment(field.split("-")[0]).getMessage());
-    }
-
-
-    public void transcode(Terser tmp, List<String> keys, String value, List<MapperError> errorList) throws HL7Exception {
+	public void transcode(Terser tmp, List<String> keys, String value) throws HL7Exception {
         TranscodingVisitor transcodeVisitor;
         Codes codeInterface;
         PropertiesCategoriesEnum property = PropertiesCategoriesEnum.valueOfProperty(value);
@@ -118,15 +109,13 @@ public class MapperEngine {
 				codeInterface = insurersCodes;
             	break;
             default:
-                throw new HL7Exception("Transcode propperty is incorrect.");
+				throw new HL7Exception("Transcode propperty is incorrect.");
         }
 
         for (String key : keys) {
             transcodeVisitor = new TranscodingVisitor(key, value, codeInterface);
             transcodeVisitor.start(tmp.getSegment(key.split("-")[0]).getMessage());
         }
-
-
     }
 
     /**
@@ -146,7 +135,7 @@ public class MapperEngine {
 
                     int i = 0;
 
-                    while (true) {
+					while (toContinue) {
 
                         var fieldRep = field.replace("#", String.valueOf(i));
 
@@ -179,7 +168,6 @@ public class MapperEngine {
                                 errorList.add(new MapperError(field, "No Category defined as: " + type));
                         }
                         i++;
-                        break;
                     }
                 } else {
                     log.info("No # on field - just a simple map");
@@ -225,19 +213,10 @@ public class MapperEngine {
         });
     }
 
-    public void swapAfterOperation(Terser tmp, List<String> fields, String value, Mapper.Category type, List<MapperError> errorList) {
+    public void swapOperation(Terser tmp, List<String> fields, String value, Mapper.Category type, List<MapperError> errorList) {
         SwapOperation swapOperation = new SwapOperation(value, fields);
         try {
             swapOperation.doOperation(tmp.getSegment(value.split("-")[0]).getMessage());
-        } catch (HL7Exception e) {
-            errorList.add(new MapperError(e.getError().name(), e.getDetail().toString()));
-        }
-    }
-
-    public void fieldAfterOperation(Terser msg, Terser tmp, List<String> fields, String value, Mapper.Category type, List<MapperError> errorList) {
-        FieldOperation fieldOperation = new FieldOperation(value, fields);
-        try {
-            fieldOperation.doOperation(tmp.getSegment(value.split("-")[0]).getMessage());
         } catch (HL7Exception e) {
             errorList.add(new MapperError(e.getError().name(), e.getDetail().toString()));
         }
@@ -378,10 +357,7 @@ public class MapperEngine {
                 } else {
                     switch (mapperCategory) {
                         case TEXT:
-                        case FIELD:
-                        case SWAP:
                         case SEGMENT:
-                        case JOIN:
                         case NUMERIC:
                             log.info("TEXT or FIELD");
                             mapper(msg, tmp, mapper.getKey(), mapper.getValue(), mapperCategory, errorList);
@@ -393,17 +369,14 @@ public class MapperEngine {
                         case ADD_SNS:
                             addFieldSNS(tmp, msg, mapper.getKey(), mapper.getValue(), errorList);
                             break;
-                        case AFTER_JOIN_FIELDS:
+						case JOIN:
                             joinFields(tmp, mapper.getKey(), mapper.getValue(), errorList);
                             break;
-                        case AFTER_FIELD:
-                            fieldAfterOperation(msg, tmp, mapper.getKey(), mapper.getValue(), mapperCategory, errorList);
-                            break;
-                        case AFTER_SWAP:
-                            swapAfterOperation(tmp, mapper.getKey(), mapper.getValue(), mapperCategory, errorList);
+						case SWAP:
+                            swapOperation(tmp, mapper.getKey(), mapper.getValue(), mapperCategory, errorList);
                             break;
                         case TRANSCODING:
-                            transcode(tmp, mapper.getKey(), mapper.getValue(), errorList);
+							transcode(tmp, mapper.getKey(), mapper.getValue());
                             break;
                         case CLEAR_IF:
                             clearIfOperation(tmp, mapper.getKey(), mapper.getValue(), errorList);
@@ -411,9 +384,9 @@ public class MapperEngine {
                         case REPLACE:
                             replaceOperation(tmp, mapper.getKey(), mapper.getValue(), errorList);
                             break;
-					case TEXT_IF:
-						textIf(msg, tmp, mapper.getKey(), mapper.getValue(), errorList);
-						break;
+						case TEXT_IF:
+							textIf(msg, tmp, mapper.getKey(), mapper.getValue(), errorList);
+							break;
                         default:
                             errorList.add(new MapperError(mapper.getKey().toString(), "No Category: " + mapperCategory));
                     }

--- a/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
+++ b/src/main/java/com/example/demopugspring/engine/operation/AbstractOperation.java
@@ -46,7 +46,7 @@ public abstract class AbstractOperation {
 	protected List<String> keys;
 	protected String value;
 
-	private boolean useOriginalValue = true;
+	private boolean useOriginalValue;
 
 	protected ArrayList<MapperError> errors = new ArrayList<>();
 
@@ -65,13 +65,13 @@ public abstract class AbstractOperation {
 		this.outgoingTerser = outgoingTerser;
 
 		this.keys = keys;
+		this.useOriginalValue = false;
 
 		if (value.startsWith(USE_MSG_VALUE_PREFIX)) {
 			this.value = value.substring(USE_MSG_VALUE_PREFIX.length());
 			this.useOriginalValue = true;
 		} else if (value.startsWith(USE_TMP_VALUE_PREFIX)) {
 			this.value = value.substring(USE_TMP_VALUE_PREFIX.length());
-			this.useOriginalValue = false;
 		} else {
 			this.value = value;
 		}

--- a/src/main/resources/templates/mappers/create.pug
+++ b/src/main/resources/templates/mappers/create.pug
@@ -23,7 +23,7 @@ html(lang="en")
                         input(type="text" id="value" name="value")
                         label(for="category") Category
                         select(id="category" name="category")
-                            each val in ["TEXT", "FIELD", "TRANSCODING", "SWAP", "SEGMENT", "JOIN", "NUMERIC", "CONTACT", "AFTER_SWAP", "AFTER_FIELD", "AFTER_JOIN_FIELDS", "CLEAR_IF", "REPLACE", "ADD_SNS", "TEXT_IF"]
+                            each val in ["TEXT", "FIELD", "TRANSCODING", "SWAP", "SEGMENT", "JOIN", "NUMERIC", "CONTACT", "CLEAR_IF", "REPLACE", "ADD_SNS", "TEXT_IF"]
                                 option= val
                         button.pure-button.pure-button-primary(type="submit") Create
     include ../includes/footer

--- a/src/main/resources/templates/mappers/edit.pug
+++ b/src/main/resources/templates/mappers/edit.pug
@@ -23,7 +23,7 @@ html(lang="en")
                         input(type="text" id="value" name="value" value=mapper.value)
                         label(for="category") Category
                         select(id="category" name="category")
-                            each val in ["TEXT", "FIELD", "TRANSCODING", "SWAP", "SEGMENT", "JOIN", "NUMERIC", "CONTACT", "AFTER_SWAP", "AFTER_FIELD", "AFTER_JOIN_FIELDS", "CLEAR_IF", "REPLACE", "ADD_SNS", "TEXT_IF"]
+                            each val in ["TEXT", "FIELD", "TRANSCODING", "SWAP", "SEGMENT", "JOIN", "NUMERIC", "CONTACT", "CLEAR_IF", "REPLACE", "ADD_SNS", "TEXT_IF"]
                                 if (val == mapper.category)
                                     option(selected)= val
                                 else

--- a/src/test/java/com/example/demopugspring/engine/MapperEngineTest.java
+++ b/src/test/java/com/example/demopugspring/engine/MapperEngineTest.java
@@ -205,7 +205,7 @@ class MapperEngineTest {
 
 		String[] testeListaKeys = {"/PID-28"};
 		meng.countryCodes = codes;
-		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS", errors);
+		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS");
 		assertEquals(toBeReturned, terserSpy.get("/PID-28-1"));
 	}
 
@@ -230,7 +230,7 @@ class MapperEngineTest {
 
 		String[] testeListaKeys = { "/INSURANCE/IN1-3" };
 		meng.insurersCodes = codes;
-		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "INSURERS-CODES", errors);
+		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "INSURERS-CODES");
 		assertEquals(toBeReturned, terserSpy.get("/INSURANCE/IN1-3"));
 	}
 
@@ -253,7 +253,7 @@ class MapperEngineTest {
 
 		String[] testeListaKeys = {"/PATIENT/PID-28"};
 		meng.countryCodes = codes;
-		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS", errors);
+		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS");
 		assertEquals(toBeReturned, terserSpy.get("/PATIENT/PID-28-1"));
 	}
 
@@ -279,14 +279,14 @@ class MapperEngineTest {
 
 		String[] testeListaKeys = {"/PID-3(#)-4"};
 		meng.identificationCodes = codes;
-		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "IDENTIFICATIONS", errors);
+		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "IDENTIFICATIONS");
 		assertEquals(toBeReturned, terserSpy.get("/PID-3(0)-4"));
 		assertEquals(toBeReturned2, terserSpy.get("/PID-3(1)-4"));
 
 	}
 
 	@Test
-	void testAfterField() throws HL7Exception {
+	void testFieldRefactored() throws HL7Exception {
 		String toBeReturned = "CUFC";
 		String messageString = "MSH|^~\\&|GH|CUFC|ehCOS|TESTE|20201117172651||ADT^A40|1604236349|P|2.4|||AL\r" +
 				"PID|||42341818^^^JMS^NS~684028^^^CUFC^NS|" + toBeReturned + "^^^NIF^PT|SEGUNDO^CLIENTE TESTE ECOS CUFC O||19821209|M|||^^^^^1||^^^^^^900000000|||||||||||||||1^PORTUGAL||N\r";
@@ -297,7 +297,7 @@ class MapperEngineTest {
 
 		MapperEngine meng = new MapperEngine();
 		String[] testeListaKeys = { "/MSH-6" };
-		meng.fieldAfterOperation(terserSpy, terserSpy, Arrays.asList(testeListaKeys), "/MSH-4", Category.AFTER_FIELD, errors);
+		meng.mapper(terserSpy, terserSpy, Arrays.asList(testeListaKeys), "/MSH-4", Category.FIELD, errors);
 		assertEquals(toBeReturned, terserSpy.get("/MSH-6"));
 	}
 
@@ -320,7 +320,7 @@ class MapperEngineTest {
 
 		String[] testeListaKeys = { "/PID-23" };
 		meng.countryCodes = codes;
-		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS", errors);
+		meng.transcode(terserSpy, Arrays.asList(testeListaKeys), "GH-LOCATIONS");
 		assertEquals(toBeReturned, terserSpy.get("/PID-23-1"));
 	}
 
@@ -493,7 +493,7 @@ class MapperEngineTest {
 	}
 
 	@Test
-	void testAfterFieldEmpty() throws HL7Exception {
+	void testFieldRefatorEmpty() throws HL7Exception {
 		String toBeReturned = "CUFC";
 		String messageString = "MSH|^~\\&|GH|CUFC|ehCOS||20201117172651||ADT^A40|1604236349|P|2.4|||AL\r" +
 				"PID|||42341818^^^JMS^NS~684028^^^CUFC^NS|" + toBeReturned + "^^^NIF^PT|SEGUNDO^CLIENTE TESTE ECOS CUFC O||19821209|M|||^^^^^1||^^^^^^900000000|||||||||||||||1^PORTUGAL||N\r";
@@ -504,7 +504,7 @@ class MapperEngineTest {
 
 		MapperEngine meng = new MapperEngine();
 		String[] testeListaKeys = { "/MSH-6" };
-		meng.fieldAfterOperation(terserSpy, terserSpy, Arrays.asList(testeListaKeys), "/MSH-4", Category.AFTER_FIELD, errors);
+		meng.mapper(terserSpy, terserSpy, Arrays.asList(testeListaKeys), "/MSH-4", Category.FIELD, errors);
 		assertEquals(toBeReturned, terserSpy.get("/MSH-6"));
 	}
 


### PR DESCRIPTION
* Removed AFTER_* categories and the categories know manipulate the tmp message
* Updated the MapperEnigneTest so it correspond to the method signature.
* AbstractOperation now operates by default on the TMP message instead of the MSG message